### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gh-docker.yml
+++ b/.github/workflows/gh-docker.yml
@@ -10,7 +10,7 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@main    
       - name: Publish
-        uses: elgohr/Publish-Docker-Github-Action@master 
+        uses: elgohr/Publish-Docker-Github-Action@v5 
         with:
           name: fonoster/seet
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore